### PR TITLE
Update firebase.js

### DIFF
--- a/client/react/src/api/firebase.js
+++ b/client/react/src/api/firebase.js
@@ -815,9 +815,9 @@ export const getSettingsFromFbase = () => {
 
 export const saveSettingsToFbase = data => {
   const db = firebase.firestore();
-  db.settings({
-    timestampsInSnapshots: true,
-  });
+//   db.settings({
+//     timestampsInSnapshots: true,
+//   });
 
   data.updatedBy = firebase.auth().currentUser.uid;
   data.updatedAt = dayjs().format('YYYY-MM-DD HH:mm:ss.ms Z');


### PR DESCRIPTION
As latest firebase doesn't require timestampsInSnapshots setting. It's true by default